### PR TITLE
feat(download): 实现客户端直链下载

### DIFF
--- a/emby2Alist/nginx/conf.d/emby.conf
+++ b/emby2Alist/nginx/conf.d/emby.conf
@@ -78,6 +78,12 @@ server{
     location ~* /Items/([^/]+)/Download {
         js_content emby2Pan.redirect2Pan;
     }
+    # for android download ,this is SyncService api
+    location ~* /Sync/JobItems/(.*)/File {
+		# Cache alist direct link
+        add_header    Cache-Control  max-age=3600;
+        js_content emby2Pan.redirect2Pan;
+    }
 
     # Cache the images
     location ~ /Items/(.*)/Images {

--- a/emby2Alist/nginx/conf.d/util.js
+++ b/emby2Alist/nginx/conf.d/util.js
@@ -25,7 +25,7 @@ function getItemInfo(r) {
   const embyHost = config.embyHost;
   const embyApiKey = config.embyApiKey;
   const regex = /[A-Za-z0-9]+/g;
-  const itemId = r.uri.replace("emby", "").replace(/-/g, "").match(regex)[1];
+  const itemId = r.uri.replace("emby", "").replace("Sync", "").replace(/-/g, "").match(regex)[1];
   const mediaSourceId = r.args.MediaSourceId
     ? r.args.MediaSourceId
     : r.args.mediaSourceId;
@@ -34,11 +34,16 @@ function getItemInfo(r) {
     ? r.args["X-Emby-Token"]
     : r.args.api_key;
   api_key = api_key ? api_key : embyApiKey;
+  // 判断是否app下载
   let itemInfoUri = "";
-  if (mediaSourceId) {
-    itemInfoUri = `${embyHost}/Items/${itemId}/PlaybackInfo?MediaSourceId=${mediaSourceId}&api_key=${api_key}`;
+  if (r.uri.includes("JobItems")) {
+		itemInfoUri = `${embyHost}/Sync/JobItems?api_key=${api_key}`;
   } else {
-    itemInfoUri = `${embyHost}/Items/${itemId}/PlaybackInfo?api_key=${api_key}`;
+    if (mediaSourceId) {
+			itemInfoUri = `${embyHost}/Items/${itemId}/PlaybackInfo?MediaSourceId=${mediaSourceId}&api_key=${api_key}`;
+    } else {
+			itemInfoUri = `${embyHost}/Items/${itemId}/PlaybackInfo?api_key=${api_key}`;
+    }
   }
   return { itemId, mediaSourceId, Etag, api_key, itemInfoUri };
 }


### PR DESCRIPTION
已解决
1.测试安卓客户端视频以及音乐直链下载功能可用，前提为所有文件来源为AList。
2.网盘有的文件会重定向下载到网盘直链，网盘没有的文件但归AList管理也可下载，会走服务器流量中转。

未解决
1.测试外挂字幕视频，只会下载视频文件本身，不会携带下载字幕文件，且由于安卓客户端无法单独手动下载字幕文件。
2.暂未测试文件夹的下载，下载到其他设备。

注意点
1.媒体质量需要选择不转码类型，Original。
2.下载位置最好选Download文件夹，这样其他应用可以访问下载内容。
3.下载后的视频外部打开方式只有几个，暂不知道原因。
4.客户端的下载原本就是经常失败且不会重试，需要手动清理后台重新进入任务栏就会弹出进度条。

测试截图
![Screenshot_2023-09-23-23-26-04-529_com mb android tg](https://github.com/bpking1/embyExternalUrl/assets/42368856/647cc369-2d24-412c-a62e-fa4d5abd4abc)
![image](https://github.com/bpking1/embyExternalUrl/assets/42368856/27f6587e-dd30-45db-8882-d1f6a1af0e68)
![image](https://github.com/bpking1/embyExternalUrl/assets/42368856/34a78b6b-8de3-47f6-ae49-c1707467018a)
![image](https://github.com/bpking1/embyExternalUrl/assets/42368856/aa2b4bff-59bb-499d-8591-8c2c04c22c49)
![image](https://github.com/bpking1/embyExternalUrl/assets/42368856/89072abf-0585-42d1-b2f1-004fc08f9322)
