### PR TITLE
fix(emby2Alist_proxy): 按照emby社区讨论,复用gzip、禁用api文档设置、添加SSL示例配置、初步修复socket远程控制功能

### DIFF
--- a/emby2Alist/nginx/conf.d/emby.conf
+++ b/emby2Alist/nginx/conf.d/emby.conf
@@ -26,13 +26,17 @@ server{
         proxy_pass $emby;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header Connection $http_connection;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Protocol $scheme;
         proxy_set_header X-Forwarded-Host $http_host;
+        proxy_connect_timeout 1h;
+        proxy_send_timeout 1h;
+        proxy_read_timeout 1h;
+        tcp_nodelay on;  ## Sends data as fast as it can not buffering large chunks, saves about 200ms per request.
     }
      # Cache the Subtitles
     location ~* /videos/(.*)/Subtitles {

--- a/emby2Alist/nginx/conf.d/emby.conf
+++ b/emby2Alist/nginx/conf.d/emby.conf
@@ -5,25 +5,58 @@ js_import embyLive from emby-live.js;
 # Cache images, subtitles
 proxy_cache_path /var/cache/nginx/images levels=1:2 keys_zone=emby_images:100m max_size=1g inactive=30d use_temp_path=off;
 proxy_cache_path /var/cache/nginx/emby/subtitles levels=1:2 keys_zone=emby_subtitles:10m max_size=1g inactive=30d use_temp_path=off;
-server{
-    gzip on;
+## The below will force all nginx traffic to SSL, make sure all other server blocks only listen on 443
+# server {
+#     listen 80 default_server;
+#     server_name _;
+#     return 301 https://$host$request_uri;
+# }
+## Start of actual server blocks
+server {
+    set $emby http://172.17.0.1:8096;  #emby/jellyfin address
+    # listen [::]:443 ssl http2;	## Listens on port 443 IPv6 with http2 and ssl enabled
+    # listen 443 ssl http2;	## Listens on port 443 IPv4 with http2 and ssl enabled
     listen 80;
     server_name default;
+    ## SSL SETTINGS ##
+    # ssl_session_timeout 30m;
+    # ssl_protocols TLSv1.2 TLSv1.1 TLSv1;
+	# ssl_certificate      ssl/pub.pem;  ## Location of your public PEM file.
+	# ssl_certificate_key  ssl/pvt.pem;  ## Location of your private PEM file.
+    # ssl_session_cache shared:SSL:10m;
+    ## Compresses the content to the client, speeds up client browsing.
+    gzip on;   
+        gzip_disable "msie6";
+        gzip_comp_level 6;
+        gzip_min_length 1100;
+        gzip_buffers 16 8k;
+        gzip_proxied any;
+        gzip_types
+            text/plain
+            text/css
+            text/js
+            text/xml
+            text/javascript
+            application/javascript
+            application/x-javascript
+            application/json
+            application/xml
+            application/rss+xml
+            image/svg+xml;
     ## The default `client_max_body_size` is 1M, this might not be enough for some posters, etc.
     client_max_body_size 20M;
-    subrequest_output_buffer_size 20M;
     # # Security / XSS Mitigation Headers
     # add_header X-Frame-Options "SAMEORIGIN";
     # add_header X-XSS-Protection "1; mode=block";
     # add_header X-Content-Type-Options "nosniff";
     # aliDrive direct stream need no-referrer
     add_header 'Referrer-Policy' 'no-referrer';
-    set $emby http://172.17.0.1:8096;  #emby/jellyfin address
 
     # Proxy sockets traffic for jellyfin-mpv-shim and webClient
     location ~* /(socket|embywebsocket) {
         # Proxy emby/jellyfin Websockets traffic
         proxy_pass $emby;
+        ## WEBSOCKET SETTINGS ## Used to pass two way real time info to and from emby and the client.
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $http_connection;
@@ -38,7 +71,7 @@ server{
         proxy_read_timeout 1h;
         tcp_nodelay on;  ## Sends data as fast as it can not buffering large chunks, saves about 200ms per request.
     }
-     # Cache the Subtitles
+    # Cache the Subtitles
     location ~* /videos/(.*)/Subtitles {
         proxy_pass $emby;
         proxy_set_header Host $host;
@@ -127,9 +160,16 @@ server{
         add_header X-Cache-Status $upstream_cache_status; # This is only to check if cache is working
     }
 
+    ## Disables access to swagger/openapi interface
+    location ~* /(swagger|openapi) {
+        return 404;
+    }
+
     location / {
         # Proxy main emby/jellyfin traffic
         proxy_pass $emby;
+        # client_max_body_size 1000M;  ## Allows for mobile device large photo uploads.
+        #proxy_set_header X-Real-IP $http_CF_Connecting_IP;  ## if you use cloudflare un-comment this line and comment out above line.
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -138,5 +178,16 @@ server{
         proxy_set_header X-Forwarded-Host $http_host;
         # Disable buffering when the nginx proxy gets very resource heavy upon streaming
         proxy_buffering off;
+
+        ## ADDITIONAL SECURITY SETTINGS ##
+        ## Optional settings to improve security ##
+        ## add these after you have completed your testing and ssl setup ##
+        ## NOTICE: For the Strict-Transport-Security setting below, I would recommend ramping up to this value ##
+        ##         See https://hstspreload.org/ read through the "Deployment Recommendations" section first!   ##
+        # add_header 'Referrer-Policy' 'origin-when-cross-origin';
+        # add_header Strict-Transport-Security "max-age=15552000; preload" always;
+        # add_header X-Frame-Options "SAMEORIGIN" always;
+        # add_header X-Content-Type-Options "nosniff" always;
+        # add_header X-XSS-Protection "1; mode=block" always;
     }
 }


### PR DESCRIPTION
参考链接: 
https://emby.media/community/index.php?/topic/93074-how-to-emby-with-nginx-with-windows-specific-tips-and-csp-options/