### PR TITLE
fix(emby2Alist_bug): 更换PlaybackInfo为Items解决图片等无播放时长项目的无法直链下载问题

### DIFF
--- a/emby2Alist/nginx/conf.d/emby.conf
+++ b/emby2Alist/nginx/conf.d/emby.conf
@@ -3,7 +3,7 @@ js_path /etc/nginx/conf.d/;
 js_import emby2Pan from emby.js;
 js_import embyLive from emby-live.js;
 # Cache images, subtitles
-proxy_cache_path /var/cache/nginx/images levels=1:2 keys_zone=emby_images:100m max_size=1g inactive=30d use_temp_path=off;
+proxy_cache_path /var/cache/nginx/emby/images levels=1:2 keys_zone=emby_images:100m max_size=1g inactive=30d use_temp_path=off;
 proxy_cache_path /var/cache/nginx/emby/subtitles levels=1:2 keys_zone=emby_subtitles:10m max_size=1g inactive=30d use_temp_path=off;
 ## The below will force all nginx traffic to SSL, make sure all other server blocks only listen on 443
 # server {
@@ -134,7 +134,7 @@ server {
     location ~* /Items/([^/]+)/Download {
         js_content emby2Pan.redirect2Pan;
     }
-    # for android download ,this is SyncService api
+    # Emby for android download ,this is SyncService api only Emby
     location ~* /Sync/JobItems/(.*)/File {
 		# Cache alist direct link
         add_header    Cache-Control  max-age=3600;

--- a/emby2Alist/nginx/conf.d/emby.js
+++ b/emby2Alist/nginx/conf.d/emby.js
@@ -14,7 +14,7 @@ async function redirect2Pan(r) {
   //fetch mount emby/jellyfin file path
   const itemInfo = util.getItemInfo(r);
   r.warn(`itemInfoUri: ${itemInfo.itemInfoUri}`);
-  const embyRes = await fetchEmbyFilePath(itemInfo.itemInfoUri, itemInfo.Etag, itemInfo.itemId);
+  const embyRes = await fetchEmbyFilePath(itemInfo.itemInfoUri, itemInfo.itemId);
   if (embyRes.message.startsWith("error")) {
     r.error(embyRes.message);
     r.return(500, embyRes.message);
@@ -219,20 +219,15 @@ async function fetchAlistPathApi(alistApiPath, alistFilePath, alistToken) {
   }
 }
 
-async function fetchEmbyFilePath(itemInfoUri, Etag, itemId) {
+async function fetchEmbyFilePath(itemInfoUri, itemId) {
   let rvt = {
     "message": "success",
     "protocol": "File", // MediaSourceInfo{ Protocol }, string ($enum)(File, Http, Rtmp, Rtsp, Udp, Rtp, Ftp, Mms)
-    "path": null
+    "path": ""
   };
-  // 1: 原始, 2: JobItems返回值
-  let resultType = 1;
-  if (itemInfoUri.includes("JobItems")) {
-    resultType = 2;
-  }
   try {
     const res = await ngx.fetch(itemInfoUri, {
-      method: resultType == 2 ? "GET" : "POST",
+      method: "GET",
       headers: {
         "Content-Type": "application/json;charset=utf-8",
         "Content-Length": 0,
@@ -245,7 +240,7 @@ async function fetchEmbyFilePath(itemInfoUri, Etag, itemId) {
         rvt.message = `error: emby_api itemInfoUri response is null`;
         return rvt;
       }
-      if (resultType == 2) {
+      if (itemInfoUri.includes("JobItems")) {
         const jobItem = result.Items.find(o => o.Id == itemId);
         if (jobItem) {
           rvt.protocol = jobItem.MediaSource.Protocol;
@@ -255,18 +250,23 @@ async function fetchEmbyFilePath(itemInfoUri, Etag, itemId) {
           return rvt;
         }
       } else {
-        if (Etag) {
-          const mediaSource = result.MediaSources.find((m) => m.ETag == Etag);
-          if (mediaSource && mediaSource.Path) {
-            rvt.protocol = mediaSource.Protocol;
-            rvt.path = mediaSource.Path;
+        const item = result.Items[0];
+        if (!item) {
+          rvt.message = `error: emby_api /Items response is null`;
+          return rvt;
+        }
+        if (item.MediaSources) {
+          rvt.protocol = item.MediaSources[0].Protocol;
+          rvt.path = item.MediaSources[0].Path;
+          // strm file internal text maybe have URIEncode
+          if (item.Path.toLowerCase().endsWith(".strm")) {
+            rvt.path = decodeURI(rvt.path);
           }
         } else {
-          rvt.protocol = result.MediaSources[0].Protocol;
-          rvt.path = result.MediaSources[0].Path;
+          // "MediaType": "Photo"... not have "MediaSources" field
+          rvt.path = item.Path;
         }
       }
-      rvt.path = decodeURI(rvt.path);
       return rvt;
     } else {
       rvt.message = `error: emby_api ${res.status} ${res.statusText}`;

--- a/emby2Alist/nginx/conf.d/util.js
+++ b/emby2Alist/nginx/conf.d/util.js
@@ -45,26 +45,18 @@ function getItemInfo(r) {
   const embyApiKey = config.embyApiKey;
   const regex = /[A-Za-z0-9]+/g;
   const itemId = r.uri.replace("emby", "").replace("Sync", "").replace(/-/g, "").match(regex)[1];
-  const mediaSourceId = r.args.MediaSourceId
-    ? r.args.MediaSourceId
-    : r.args.mediaSourceId;
-  const Etag = r.args.Tag;
   let api_key = r.args["X-Emby-Token"]
     ? r.args["X-Emby-Token"]
     : r.args.api_key;
   api_key = api_key ? api_key : embyApiKey;
-  // 判断是否app下载
   let itemInfoUri = "";
+  // is /Sync/JobItems API?
   if (r.uri.includes("JobItems")) {
 		itemInfoUri = `${embyHost}/Sync/JobItems?api_key=${api_key}`;
   } else {
-    if (mediaSourceId) {
-			itemInfoUri = `${embyHost}/Items/${itemId}/PlaybackInfo?MediaSourceId=${mediaSourceId}&api_key=${api_key}`;
-    } else {
-			itemInfoUri = `${embyHost}/Items/${itemId}/PlaybackInfo?api_key=${api_key}`;
-    }
+    itemInfoUri = `${embyHost}/Items?Ids=${itemId}&Fields=MediaStreams,Path&Limit=1&api_key=${api_key}`;
   }
-  return { itemId, mediaSourceId, Etag, api_key, itemInfoUri };
+  return { itemInfoUri, itemId, api_key };
 }
 
 export default {

--- a/emby2Alist/nginx/conf.d/util.js
+++ b/emby2Alist/nginx/conf.d/util.js
@@ -45,18 +45,25 @@ function getItemInfo(r) {
   const embyApiKey = config.embyApiKey;
   const regex = /[A-Za-z0-9]+/g;
   const itemId = r.uri.replace("emby", "").replace("Sync", "").replace(/-/g, "").match(regex)[1];
+  const mediaSourceId = r.args.MediaSourceId
+    ? r.args.MediaSourceId
+    : r.args.mediaSourceId;
+  const Etag = r.args.Tag;
   let api_key = r.args["X-Emby-Token"]
     ? r.args["X-Emby-Token"]
     : r.args.api_key;
   api_key = api_key ? api_key : embyApiKey;
   let itemInfoUri = "";
-  // is /Sync/JobItems API?
   if (r.uri.includes("JobItems")) {
 		itemInfoUri = `${embyHost}/Sync/JobItems?api_key=${api_key}`;
   } else {
-    itemInfoUri = `${embyHost}/Items?Ids=${itemId}&Fields=MediaStreams,Path&Limit=1&api_key=${api_key}`;
+    if (mediaSourceId) {
+      itemInfoUri = `${embyHost}/Items?Ids=${mediaSourceId}&Fields=Path,MediaSources&Limit=1&api_key=${api_key}`;
+    } else {
+      itemInfoUri = `${embyHost}/Items?Ids=${itemId}&Fields=Path,MediaSources&Limit=1&api_key=${api_key}`;
+    }
   }
-  return { itemInfoUri, itemId, api_key };
+  return { itemInfoUri, itemId , Etag, mediaSourceId, api_key };
 }
 
 export default {


### PR DESCRIPTION
1.更换了getItemInfo方法中的API接口，以兼容图片的直链下载，之前Emby会报类型转换错误。
~~2.去除了更换后不兼容的两个入参mediaSourceId和ETag，暂不知道对没测试到的功能有无其他影响。~~
3.恢复mediaSourceId和ETag的判断，经过Emby和Jellyfin测试，多版本直链播放无问题。
Emby Web
![image](https://github.com/bpking1/embyExternalUrl/assets/42368856/8f2645a4-f38a-41fb-9224-570a98f15f11)
Jellfin Web 因特殊原因不支持4K播放，日志里没有，没做兼容前默认会取第一个版本(4K)，兼容后取到正确版本(1080p)
![image](https://github.com/bpking1/embyExternalUrl/assets/42368856/6ed5ec21-1e94-4f0b-a9db-dec7320b178c)

