### PR TITLE
fix(emby2Alist_cache): 修复过失配置images少一级目录bug

### DIFF
--- a/emby2Alist/nginx/conf.d/emby.conf
+++ b/emby2Alist/nginx/conf.d/emby.conf
@@ -3,7 +3,7 @@ js_path /etc/nginx/conf.d/;
 js_import emby2Pan from emby.js;
 js_import embyLive from emby-live.js;
 # Cache images, subtitles
-proxy_cache_path /var/cache/nginx/images levels=1:2 keys_zone=emby_images:100m max_size=1g inactive=30d use_temp_path=off;
+proxy_cache_path /var/cache/nginx/emby/images levels=1:2 keys_zone=emby_images:100m max_size=1g inactive=30d use_temp_path=off;
 proxy_cache_path /var/cache/nginx/emby/subtitles levels=1:2 keys_zone=emby_subtitles:10m max_size=1g inactive=30d use_temp_path=off;
 ## The below will force all nginx traffic to SSL, make sure all other server blocks only listen on 443
 # server {


### PR DESCRIPTION
1.需要重启nginx。
2.需要检查/var/cache/nginx/images是否多出此目录并进行删除。
3.抱歉之前提交没看清楚。