### PR TITLE
fix(emby2Alist_PlaybackInfo): 修复PlaybackInfo反代并精确匹配范围

### DIFF
--- a/emby2Alist/nginx/conf.d/constant.js
+++ b/emby2Alist/nginx/conf.d/constant.js
@@ -1,7 +1,7 @@
 // export constant allocation
 // 根据实际情况修改下面的设置
 const embyIp = "http://172.17.0.1";
-const embyPort = 8098;
+const embyPort = 8096;
 // 这里默认emby/jellyfin的地址是宿主机,要注意iptables给容器放行端口
 const embyHost = embyIp + ":" + embyPort;
 // rclone 的挂载目录, 例如将od, gd挂载到/mnt目录下:  /mnt/onedrive  /mnt/gd ,那么这里 就填写 /mnt

--- a/emby2Alist/nginx/conf.d/emby.conf
+++ b/emby2Alist/nginx/conf.d/emby.conf
@@ -45,6 +45,8 @@ server {
             image/svg+xml;
     ## The default `client_max_body_size` is 1M, this might not be enough for some posters, etc.
     client_max_body_size 20M;
+    # default is 4k
+    subrequest_output_buffer_size 200k;
     # # Security / XSS Mitigation Headers
     # add_header X-Frame-Options "SAMEORIGIN";
     # add_header X-XSS-Protection "1; mode=block";
@@ -92,9 +94,10 @@ server {
 
     # Proxy PlaybackInfo
     location ~ ^(.*)/proxy(/.*)$ {
+        gunzip on; # Jellyfin has gzip,subrequest need this,Emby no gzip but compatible
         client_body_in_file_only clean;
         rewrite ^(.*)/proxy(/.*)$ $1$2 break;
-        proxy_pass $emby;
+        proxy_pass $emby$request_uri; # Emby need $request_uri,Jellyfin not need but compatible
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -108,8 +111,12 @@ server {
         add_header X-Proxy-Success "yes";
     }
     location ~* /Items/(.*)/PlaybackInfo {
-        client_body_in_file_only clean;
-        js_content emby2Pan.transferPlaybackInfo;
+    	client_body_in_file_only clean;
+    	if ($args ~* "IsPlayback=true") {
+        	js_content emby2Pan.transferPlaybackInfo;
+        	break;
+		}
+		proxy_pass $emby;
     }
     # Redirect the stream to njs
     location ~* /videos/(.*)/stream {

--- a/emby2Alist/nginx/conf.d/util.js
+++ b/emby2Alist/nginx/conf.d/util.js
@@ -5,6 +5,9 @@ function proxyUri(uri) {
 }
 
 function appendUrlArg(u, k, v) {
+  if (u.includes(k)) {
+    return u;
+  }
   return u + (u.includes("?") ? "&" : "?") + `${k}=${v}`;
 }
 
@@ -17,10 +20,14 @@ function addDefaultApiKey(r, u) {
   return url;
 }
 
-function generateUrl(r, host, uri) {
+function generateUrl(r, host, uri, ignoreSpChar) {
   let url = host + uri;
   let isFirst = true;
   for (const key in r.args) {
+    // a few players not support special character
+    if (ignoreSpChar && (key === "X-Emby-Client" || key === "X-Emby-Device-Name")) {
+      continue;
+    }
     url += isFirst ? "?" : "&";
     url += `${key}=${r.args[key]}`;
     isFirst = false;
@@ -55,7 +62,7 @@ function getItemInfo(r) {
   api_key = api_key ? api_key : embyApiKey;
   let itemInfoUri = "";
   if (r.uri.includes("JobItems")) {
-		itemInfoUri = `${embyHost}/Sync/JobItems?api_key=${api_key}`;
+	itemInfoUri = `${embyHost}/Sync/JobItems?api_key=${api_key}`;
   } else {
     if (mediaSourceId) {
       itemInfoUri = `${embyHost}/Items?Ids=${mediaSourceId}&Fields=Path,MediaSources&Limit=1&api_key=${api_key}`;


### PR DESCRIPTION
1.修复PlaybackInfo反代并精确匹配范围,只代理IsPlayback=true单次播放请求,Emby会用此接口在详情页中多次调用,Jellyfin只在播放时调用一次,测试下来视频多版本直链播放正常,但直播暂未测试,应该能兼容。
2.去除了一段check if it is local resource代码,本地视频修复在redirect2Pan中已做处理。
3.根据njs文档去除了cloneHeaders操作,subrequest共享请求头。
4.反代PlaybackInfo的好处现在可以支持JellyfinWeb端的4K-HEVC直链播放,之前不行。
5.测试中JellyfinWeb端播放内挂字幕可能存在提取字幕的内存泄露问题,Jellyfin的ffmpeg占了2G内存还在继续飙升,此为Jellyfin的Bug本人无法修复,Emby无此Bug,故Jellyfin播放内挂字幕视频或内挂字幕视频切换字幕后密切关注内存占用或用docker版Jellyfin限制最大内存。

Emby测试日志
![Emby-01](https://github.com/bpking1/embyExternalUrl/assets/42368856/ec337342-351a-4706-bb88-ad5051256587)

Jellyfin测试日志
![Jellyfin-1](https://github.com/bpking1/embyExternalUrl/assets/42368856/f13eb030-5721-4fbc-b69a-84f00e0382d7)
![Jellyfin-02](https://github.com/bpking1/embyExternalUrl/assets/42368856/d7a9dc84-6d7c-4c32-942c-34684eb81f82)

