### PR TITLE
feat(emby2Alist_plex): 实验性质兼容支持了Plex的直链播放

### DIFF
--- a/emby2Alist/nginx/conf.d/constant.js
+++ b/emby2Alist/nginx/conf.d/constant.js
@@ -12,7 +12,7 @@ const alistIp = "http://172.17.0.1";
 const alistPort = 5244;
 // 访问宿主机上5244端口的alist地址, 要注意iptables给容器放行端口
 const alistAddr = alistIp + ":" + alistPort;
-// emby/jellyfin api key, 在emby/jellyfin后台设置
+// emby/jellyfin api key, 在emby/jellyfin后台设置, plex不会用到此值
 const embyApiKey = "f839390f50a648fd92108bc11ca6730a";
 // 公网域名, 按需填写, eg: http://youralist.com
 const publicDomain = "";

--- a/emby2Alist/nginx/conf.d/emby.conf
+++ b/emby2Alist/nginx/conf.d/emby.conf
@@ -13,7 +13,7 @@ proxy_cache_path /var/cache/nginx/emby/subtitles levels=1:2 keys_zone=emby_subti
 # }
 ## Start of actual server blocks
 server {
-    set $emby http://172.17.0.1:8096;  #emby/jellyfin address
+    set $emby http://172.17.0.1:8096;  #emby/jellyfin/plex address
     # listen [::]:443 ssl http2;	## Listens on port 443 IPv6 with http2 and ssl enabled
     # listen 443 ssl http2;	## Listens on port 443 IPv4 with http2 and ssl enabled
     listen 80;
@@ -54,6 +54,7 @@ server {
     # aliDrive direct stream need no-referrer
     add_header 'Referrer-Policy' 'no-referrer';
 
+    # emby/jellyfin Start
     # Proxy sockets traffic for jellyfin-mpv-shim and webClient
     location ~* /(socket|embywebsocket) {
         # Proxy emby/jellyfin Websockets traffic
@@ -171,6 +172,24 @@ server {
     location ~* /(swagger|openapi) {
         return 404;
     }
+    # emby/jellyfin End
+
+    # PlexMediaServer Start
+    # Redirect the stream to njs
+    location ~* /library/parts/(\d+)/(\d+)/file {
+        # Cache alist direct link
+        # add_header    Cache-Control  max-age=3600;
+        # proxy_pass $goalist;
+        js_content emby2Pan.redirect2Pan;
+    }
+    location ~* /video/:/transcode/universal/start {
+    	gunzip on;
+        # Cache alist direct link
+        # add_header    Cache-Control  max-age=3600;
+        # proxy_pass $goalist;
+        js_content emby2Pan.redirect2Pan;
+    }
+    # PlexMediaServer End
 
     location / {
         # Proxy main emby/jellyfin traffic

--- a/emby2Alist/nginx/conf.d/emby.js
+++ b/emby2Alist/nginx/conf.d/emby.js
@@ -11,23 +11,34 @@ async function redirect2Pan(r) {
   const alistIp = config.alistIp;
   const publicDomain = config.publicDomain;
   const changeAlistToEmby = config.changeAlistToEmby;
-  //fetch mount emby/jellyfin file path
-  const itemInfo = util.getItemInfo(r);
+  const isPlex = JSON.stringify(r.args).includes("X-Plex");
+  //fetch mount emby/jellyfin/plex file path
+  let itemInfo = null;
+  if (isPlex) {
+    itemInfo = await util.getPlexItemInfo(r);
+  } else {
+    itemInfo = await util.getItemInfo(r);
+  }
   r.warn(`itemInfoUri: ${itemInfo.itemInfoUri}`);
-  const embyRes = await fetchEmbyFilePath(itemInfo.itemInfoUri, itemInfo.itemId, itemInfo.Etag, itemInfo.mediaSourceId);
-  if (embyRes.message.startsWith("error")) {
-    r.error(embyRes.message);
-    r.return(500, embyRes.message);
+  let mediaServerRes = null;
+  if (isPlex) {
+  	mediaServerRes = await fetchPlexFilePath(itemInfo.itemInfoUri, itemInfo.mediaIndex, itemInfo.partIndex);
+  } else {
+  	mediaServerRes = await fetchEmbyFilePath(itemInfo.itemInfoUri, itemInfo.itemId, itemInfo.Etag, itemInfo.mediaSourceId);
+  }
+  if (mediaServerRes.message.startsWith("error")) {
+    r.error(mediaServerRes.message);
+    r.return(500, mediaServerRes.message);
     return;
   }
-  r.warn(`mount emby file path: ${embyRes.path}`);
+  r.warn(`mount media_server file path: ${mediaServerRes.path}`);
 
-  // remote strm file direct
-  if ("File" != embyRes.protocol && embyRes.path) {
-    r.warn(`mount emby file protocol: ${embyRes.protocol}`);
+  // remote strm file direct, plex not supported
+  if (!isPlex && "File" != mediaServerRes.protocol && mediaServerRes.path) {
+    r.warn(`mount emby file protocol: ${mediaServerRes.protocol}`);
     if (config.allowRemoteStrmRedirect) {
-      r.warn(`!!!warnning remote strm file redirect to: ${embyRes.path}`);
-      r.return(302, embyRes.path);
+      r.warn(`!!!warnning remote strm file redirect to: ${mediaServerRes.path}`);
+      r.return(302, mediaServerRes.path);
       return;
     } else {
       // use original link
@@ -36,7 +47,7 @@ async function redirect2Pan(r) {
   }
 
   //fetch alist direct link
-  const alistFilePath = embyRes.path.replace(embyMountPath, "");
+  const alistFilePath = mediaServerRes.path.replace(embyMountPath, "");
   const alistFsGetApiPath = `${alistAddr}/api/fs/get`;
   let alistRes = await fetchAlistPathApi(
     alistFsGetApiPath,
@@ -272,4 +283,37 @@ async function fetchEmbyFilePath(itemInfoUri, itemId, Etag, mediaSourceId) {
   }
 }
 
-export default { redirect2Pan, fetchEmbyFilePath, transferPlaybackInfo };
+async function fetchPlexFilePath(itemInfoUri, mediaIndex, partIndex) {
+  let rvt = {
+    "message": "success",
+    "path": ""
+  };
+  try {
+    const res = await ngx.fetch(itemInfoUri, {
+      method: "GET",
+      headers: {
+      	"Accept": "application/json", // only plex need this
+        "Content-Type": "application/json;charset=utf-8",
+        "Content-Length": 0,
+      },
+      max_response_body_size: 65535
+    });
+    if (res.ok) {
+      const result = await res.json();
+      if (result === null || result === undefined) {
+        rvt.message = `error: plex_api itemInfoUri response is null`;
+        return rvt;
+      }
+  	  rvt.path = result.MediaContainer.Metadata[0].Media[mediaIndex].Part[partIndex].file;
+  	  return rvt;
+    } else {
+      rvt.message = `error: plex_api ${res.status} ${res.statusText}`;
+      return rvt;
+    }
+  } catch (error) {
+    rvt.message = `error: plex_api fetch mediaItemInfo failed, ${error}`;
+    return rvt;
+  }
+}
+
+export default { redirect2Pan, fetchEmbyFilePath, fetchPlexFilePath, transferPlaybackInfo };


### PR DESCRIPTION
1.参考博客中的plex直链功能并参考之前的njs实现，实验性(bug)性质支持了直链播放，因为只找到社区维护的简易API，所以实现方式比较别扭，目前存在多版本视频不能直链下载的bug。see: https://plex-docs.vercel.app
2.Plex要直链播放只需要设置远程访问-手动设置公开端口为nginx监听端口，避免客户端优先直连32400，如果路由器做了32400端口转发，不影响外部访问。
![image](https://github.com/bpking1/embyExternalUrl/assets/42368856/9abc036a-72db-4434-9be7-1f31c2686bb2)

3.PlexWeb自身存在很多问题，不支持DTS的直接播放，不支持所有非内嵌字幕的直接播放，使用起来就是已经直连云盘在接收数据了，但是Web播放器卡住不动，页签内存过载就直接白屏了，Web只支持简单格式的内嵌字幕视频，解决方案为使用对应平台的客户端，经测试，安卓客户端是没问题的。
![47dc8412c5d0b46aac999d4c3aae36ae](https://github.com/bpking1/embyExternalUrl/assets/42368856/625731e4-a8b9-46f9-b511-96aba4498485)
![baddd39444f9ca6f2069209c2f73f9d](https://github.com/bpking1/embyExternalUrl/assets/42368856/47be6ced-e630-460b-9a7d-bfdedc795907)
![cf1b5edc12c2fd2b52eed17ab3afc85](https://github.com/bpking1/embyExternalUrl/assets/42368856/8bd44d0e-3761-4dc8-b86e-fa3baf8163b6)