### PR TITLE
fix 本地硬盘资源直接使用原链播放，不查云盘

### DIFF
--- a/emby2Alist/nginx/conf.d/constant.js
+++ b/emby2Alist/nginx/conf.d/constant.js
@@ -20,6 +20,9 @@ const embyApiKey = "f839390f50a648fd92108bc11ca6730a";
 // 如果没有挂载,全部使用 strm 文件,此项填[""],必须要是数组
 const embyMountPath = ["/mnt"];
 
+// emby本地硬盘资源路径，本地硬盘资源直接使用原链接播放，不查询网盘。必须要是数组
+const embyLocalPath = ["/mnt"];
+
 // for js_set
 function getEmbyHost(r) {
   return embyHost;
@@ -38,6 +41,7 @@ export default {
   embyHost,
   embyApiKey,
   embyMountPath,
+  embyLocalPath,
   strHead: commonConfig.strHead,
 
   alistAddr: mountConfig.alistAddr,

--- a/emby2Alist/nginx/conf.d/emby.js
+++ b/emby2Alist/nginx/conf.d/emby.js
@@ -79,6 +79,12 @@ async function redirect2Pan(r) {
   }
   r.warn(`mount emby file path: ${embyRes.path}`);
 
+  // local resource use original link
+  const isLocalResource = config.embyLocalPath.some(s => embyRes.path.startsWith(s));
+  if (isLocalResource) {
+     return internalRedirect(r);
+  }
+
   // routeRule
   const routeMode = util.getRouteMode(r, embyRes.path, false, embyRes.notLocal);
   if (util.ROUTE_ENUM.proxy == routeMode) {


### PR DESCRIPTION
![image](https://github.com/bpking1/embyExternalUrl/assets/54088512/807c8f34-af8f-449f-ab2a-1d7028ff8d3f)
我emby里有本地硬盘资源和strm云盘资源。

strm播放体验很好，不过我播放本地硬盘资源的时候会去查alist上的所有云盘。最后找不到使用原链播放。

着实有点浪费资源，所以加了个本地硬盘资源变量，本地硬盘资源直接使用源链播放，不查云盘。效果如下
![image](https://github.com/bpking1/embyExternalUrl/assets/54088512/30c1af43-7063-48ab-8710-4ce22b47be37)
