### PR TITLE
播放链接添加DeviceId参数

### DIFF
--- a/embyWebAddExternalUrl/embyLaunchPotplayer.js
+++ b/embyWebAddExternalUrl/embyLaunchPotplayer.js
@@ -275,7 +275,7 @@
             streamUrl += `Download`;
             streamUrl += useRealFileName ? `/${fileName}` : "";
         }
-        streamUrl += `?api_key=${ApiClient.accessToken()}&Static=true&MediaSourceId=${mediaSourceId}`;
+        streamUrl += `?api_key=${ApiClient.accessToken()}&Static=true&MediaSourceId=${mediaSourceId}&DeviceId=${ApiClient._deviceId}`;
         let position = parseInt(itemInfo.UserData.PlaybackPositionTicks / 10000);
         let intent = await getIntent(mediaSource, position);
         console.log(streamUrl, subUrl, intent);


### PR DESCRIPTION
一些公益服通过DeviceId验证后才返回后端推流地址，故前端缺少此参数将导致播放失败