### PR TITLE
fix(emby2Alist): 多版本播放源排序边界条件异常

### DIFF
--- a/emby2Alist/nginx/conf.d/modules/emby-playback-info.js
+++ b/emby2Alist/nginx/conf.d/modules/emby-playback-info.js
@@ -7,7 +7,10 @@ function sourcesSort(mediaSources, rules) {
       let ruleVal = rules[key];
       let aVal = getNestedValue(a, key);
       let bVal = getNestedValue(b, key);
-      if (aVal === undefined) return bVal === undefined ? 0 : 1;
+      if (aVal === undefined) {
+        if (bVal === undefined) continue;
+        return 1;
+      }
       if (bVal === undefined) return -1;
       if (Array.isArray(ruleVal)) {
         for (let i in ruleVal) {


### PR DESCRIPTION
a2dcb43a3 中校验造成了一个问题：如果两者都没取到值，后续条件不再匹配了