### PR TITLE
修改内网IP的识别通过header中的X-Real-IP、Proxy-Client-IP等实现

### DIFF
--- a/emby2Alist/nginx/conf.d/common/url-util.js
+++ b/emby2Alist/nginx/conf.d/common/url-util.js
@@ -137,6 +137,19 @@ function parseUrl(url) {
   return null;
 }
 
+function getRealIp(r) {
+    const headers = r.headersIn;
+    const ip = headers["X-Forwarded-For"] ||
+        headers["X-Real-IP"] ||
+        headers["Proxy-Client-IP"] ||
+        headers["Proxy-Client-IP"] ||
+        headers["WL-Proxy-Client-IP"] ||
+        headers["HTTP_CLIENT_IP"] ||
+        headers["HTTP_X_FORWARDED_FOR"] ||
+        r.variables.remote_addr;
+    return ip;
+}
+
 export default {
   proxyUri,
   appendUrlArg,
@@ -150,4 +163,5 @@ export default {
   generateDirectStreamUrl,
   getFilePathPart,
   parseUrl,
+  getRealIp,
 }

--- a/emby2Alist/nginx/conf.d/common/util.js
+++ b/emby2Alist/nginx/conf.d/common/util.js
@@ -266,6 +266,9 @@ function getMatchedRule(r, ruleArr3D, filePath) {
     let sourceStr = filePath;
     if (!Object.values(SOURCE_STR_ENUM).includes(rule[0])) {
       sourceStr = parseExpression(r, rule[0]);
+      if (rule[0] === 'r.variables.remote_addr') {
+        sourceStr = urlUtil.getRealIp(r);
+      }
     }
     let flag = false;
     ngx.log(ngx.WARN, `sourceStrValue, ${rule[0]} = ${sourceStr}`);


### PR DESCRIPTION
当直连项目存在多重代理的情况下，无法获取到真实IP，修改为优先从header头中获取IP地址